### PR TITLE
Map nullable to null type

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -60,18 +60,25 @@ namespace Microsoft.OpenApi.Readers
             switch (inputVersion)
             {
                 case string version when version.is2_0():
+                    this.Diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi2_0;
                     VersionService = new OpenApiV2VersionService(Diagnostic);
                     doc = VersionService.LoadDocument(RootNode);
-                    this.Diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi2_0;
                     ValidateRequiredFields(doc, version);
                     break;
 
-                case string version when version.is3_0() || version.is3_1():
+                case string version when version.is3_0():
+                    this.Diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi3_0;
                     VersionService = new OpenApiV3VersionService(Diagnostic);
                     doc = VersionService.LoadDocument(RootNode);
-                    this.Diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi3_0;
                     ValidateRequiredFields(doc, version);
                     break;
+                case string version when version.is3_1():
+                    this.Diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi3_1;
+                    VersionService = new OpenApiV3VersionService(Diagnostic);
+                    doc = VersionService.LoadDocument(RootNode);
+                    ValidateRequiredFields(doc, version);
+                    break;
+
 
                 default:
                     throw new OpenApiUnsupportedSpecVersionException(inputVersion);
@@ -100,6 +107,10 @@ namespace Microsoft.OpenApi.Readers
                     break;
 
                 case OpenApiSpecVersion.OpenApi3_0:
+                    this.VersionService = new OpenApiV3VersionService(Diagnostic);
+                    element = this.VersionService.LoadElement<T>(node);
+                    break;
+                case OpenApiSpecVersion.OpenApi3_1:
                     this.VersionService = new OpenApiV3VersionService(Diagnostic);
                     element = this.VersionService.LoadElement<T>(node);
                     break;

--- a/src/Microsoft.OpenApi.Workbench/MainModel.cs
+++ b/src/Microsoft.OpenApi.Workbench/MainModel.cs
@@ -162,6 +162,7 @@ namespace Microsoft.OpenApi.Workbench
                 _version = value;
                 OnPropertyChanged(nameof(IsV2_0));
                 OnPropertyChanged(nameof(IsV3_0));
+                OnPropertyChanged(nameof(IsV3_1));
             }
         }
 
@@ -187,6 +188,12 @@ namespace Microsoft.OpenApi.Workbench
         {
             get => Version == OpenApiSpecVersion.OpenApi3_0;
             set => Version = OpenApiSpecVersion.OpenApi3_0;
+        }
+
+        public bool IsV3_1
+        {
+            get => Version == OpenApiSpecVersion.OpenApi3_1;
+            set => Version = OpenApiSpecVersion.OpenApi3_1;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.Workbench/Microsoft.OpenApi.Workbench.csproj
+++ b/src/Microsoft.OpenApi.Workbench/Microsoft.OpenApi.Workbench.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
@@ -21,11 +21,6 @@ namespace Microsoft.OpenApi.Models
         public const string Info = "info";
 
         /// <summary>
-        /// Field: Webhooks
-        /// </summary>
-        public const string Webhooks = "webhooks";
-
-        /// <summary>
         /// Field: Title
         /// </summary>
         public const string Title = "title";
@@ -81,11 +76,6 @@ namespace Microsoft.OpenApi.Models
         public const string Components = "components";
 
         /// <summary>
-        /// Field: PathItems
-        /// </summary>
-        public const string PathItems = "pathItems";
-
-        /// <summary>
         /// Field: Security
         /// </summary>
         public const string Security = "security";
@@ -129,11 +119,6 @@ namespace Microsoft.OpenApi.Models
         /// Field: Name
         /// </summary>
         public const string Name = "name";
-
-        /// <summary>
-        /// Field: Identifier
-        /// </summary>
-        public const string Identifier = "identifier";
 
         /// <summary>
         /// Field: Namespace

--- a/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Models
         /// Field: Webhooks
         /// </summary>
         public const string Webhooks = "webhooks";
-        
+
         /// <summary>
         /// Field: Title
         /// </summary>
@@ -84,7 +84,7 @@ namespace Microsoft.OpenApi.Models
         /// Field: PathItems
         /// </summary>
         public const string PathItems = "pathItems";
-        
+
         /// <summary>
         /// Field: Security
         /// </summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
@@ -21,6 +21,11 @@ namespace Microsoft.OpenApi.Models
         public const string Info = "info";
 
         /// <summary>
+        /// Field: Webhooks
+        /// </summary>
+        public const string Webhooks = "webhooks";
+        
+        /// <summary>
         /// Field: Title
         /// </summary>
         public const string Title = "title";
@@ -76,6 +81,11 @@ namespace Microsoft.OpenApi.Models
         public const string Components = "components";
 
         /// <summary>
+        /// Field: PathItems
+        /// </summary>
+        public const string PathItems = "pathItems";
+        
+        /// <summary>
         /// Field: Security
         /// </summary>
         public const string Security = "security";
@@ -119,6 +129,11 @@ namespace Microsoft.OpenApi.Models
         /// Field: Name
         /// </summary>
         public const string Name = "name";
+
+        /// <summary>
+        /// Field: Identifier
+        /// </summary>
+        public const string Identifier = "identifier";
 
         /// <summary>
         /// Field: Namespace

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -298,16 +298,6 @@ namespace Microsoft.OpenApi.Models
             Reference = schema?.Reference != null ? new(schema?.Reference) : null;
         }
 
-        public void SerializeAsV31(IOpenApiWriter writer) {
-            if (writer == null)
-            {
-                throw Error.ArgumentNull(nameof(writer));
-            }
-
-            var settings = writer.GetSettings();
-            var target = this;
-        }
-
         /// <summary>
         /// Serialize <see cref="OpenApiSchema"/> to Open Api v3.0
         /// </summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -21,9 +21,14 @@ namespace Microsoft.OpenApi.Models
 
         /// <summary>
         /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
-        /// Value MUST be a string. Multiple types via an array are not supported.
         /// </summary>
         public string Type { get; set; }
+
+        /// <summary>
+        /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
+        /// Multiple types via an array are not supported.
+        /// </summary>
+        public ISet<string> TypeArray { get; set; }  = new HashSet<string>();
 
         /// <summary>
         /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
@@ -254,6 +259,7 @@ namespace Microsoft.OpenApi.Models
         {
             Title = schema?.Title ?? Title;
             Type = schema?.Type ?? Type;
+            TypeArray = schema?.TypeArray != null ? new HashSet<string>(schema.TypeArray) : null;
             Format = schema?.Format ?? Format;
             Description = schema?.Description ?? Description;
             Maximum = schema?.Maximum ?? Maximum;
@@ -395,6 +401,9 @@ namespace Microsoft.OpenApi.Models
 
             // type
             writer.WriteProperty(OpenApiConstants.Type, Type);
+
+            // type array
+            writer.WriteOptionalCollection(OpenApiConstants.Type, TypeArray, (w, s) => w.WriteValue(s));
 
             // allOf
             writer.WriteOptionalCollection(OpenApiConstants.AllOf, AllOf, (w, s) => s.SerializeAsV3(w));
@@ -572,7 +581,7 @@ namespace Microsoft.OpenApi.Models
                     AnyOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format ??
                     OneOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format;
             }
-            
+
             writer.WriteProperty(OpenApiConstants.Format, Format);
 
             // items

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -298,6 +298,16 @@ namespace Microsoft.OpenApi.Models
             Reference = schema?.Reference != null ? new(schema?.Reference) : null;
         }
 
+        public void SerializeAsV31(IOpenApiWriter writer) {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            var settings = writer.GetSettings();
+            var target = this;
+        }
+
         /// <summary>
         /// Serialize <see cref="OpenApiSchema"/> to Open Api v3.0
         /// </summary>
@@ -400,10 +410,11 @@ namespace Microsoft.OpenApi.Models
             writer.WriteOptionalCollection(OpenApiConstants.Enum, Enum, (nodeWriter, s) => nodeWriter.WriteAny(s));
 
             // type
-            writer.WriteProperty(OpenApiConstants.Type, Type);
-
-            // type array
-            writer.WriteOptionalCollection(OpenApiConstants.Type, TypeArray, (w, s) => w.WriteValue(s));
+            if (TypeArray?.Count() == 0) {
+                writer.WriteProperty(OpenApiConstants.Type, Type);
+            } else {
+                writer.WriteOptionalCollection(OpenApiConstants.Type, TypeArray, (w, s) => w.WriteValue(s));
+            }
 
             // allOf
             writer.WriteOptionalCollection(OpenApiConstants.AllOf, AllOf, (w, s) => s.SerializeAsV3(w));
@@ -446,7 +457,9 @@ namespace Microsoft.OpenApi.Models
             writer.WriteOptionalObject(OpenApiConstants.Default, Default, (w, d) => w.WriteAny(d));
 
             // nullable
-            writer.WriteProperty(OpenApiConstants.Nullable, Nullable, false);
+            if (TypeArray?.Count() == 0) {
+                writer.WriteProperty(OpenApiConstants.Nullable, Nullable, false);
+            }
 
             // discriminator
             writer.WriteOptionalObject(OpenApiConstants.Discriminator, Discriminator, (w, s) => s.SerializeAsV3(w));

--- a/src/Microsoft.OpenApi/OpenApiSpecVersion.cs
+++ b/src/Microsoft.OpenApi/OpenApiSpecVersion.cs
@@ -15,7 +15,12 @@ namespace Microsoft.OpenApi
 
         /// <summary>
         /// Represents all patches of OpenAPI V3.0 spec (e.g. 3.0.0, 3.0.1)
-        /// </summary> 
-        OpenApi3_0
+        /// </summary>
+        OpenApi3_0,
+
+        /// <summary>
+        /// Represents all patches of OpenAPI V3.1 spec (e.g. 3.1.0, 3.1.1)
+        /// </summary>
+        OpenApi3_1
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -50,9 +50,24 @@ namespace Microsoft.OpenApi.Validations.Rules
                 return;
             }
 
-            var type = schema.Type;
+            var typeArray = schema.TypeArray;
             var format = schema.Format;
-            var nullable = schema.Nullable;
+            bool nullable;
+            string type = null;
+
+            // if nullable is available via typeArray, use it to determine if the property is nullable.
+            // Otherwise, use schema.Nullable.
+            if (typeArray != null && typeArray.Count > 1) {
+                nullable = typeArray.Contains("null");
+                typeArray.Remove("null");
+                foreach(var t in typeArray) {
+                    type = t;
+                }
+            }
+            else {
+                nullable = schema.Nullable;
+                type = schema.Type;
+            }
 
             // Before checking the type, check first if the schema allows null.
             // If so and the data given is also null, this is allowed for any type.

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -239,6 +239,9 @@
       <EmbeddedResource Include="V3Tests\Samples\OpenApiSchema\simpleSchema.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiSchema\documentWithTypeArray.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiSecurityScheme\apiKeySecurityScheme.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -1559,7 +1559,7 @@ paths: {}",
             };
 
             // Assert
-            diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 });
+            diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_1 });
             actual.Should().BeEquivalentTo(expected);
         }
 
@@ -1775,8 +1775,7 @@ paths: {}",
 
             // Assert
             actual.Should().BeEquivalentTo(expected);
-            context.Should().BeEquivalentTo(
-    new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 });
+            context.Should().BeEquivalentTo(new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_1 });
 
         }
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -993,19 +993,5 @@ get:
             diagnostic.Should().BeEquivalentTo(
                 new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_1 });
         }
-
-        [Fact]
-        public void ParseTypeSchemaShouldSucceed() {
-            // Arrange
-            // Act
-            // Assert
-        }
-
-        [Fact]
-        public void ParseTypeArrayAndTypeShouldNotSucceed() {
-            // Arrange
-            // Act
-            // Assert
-        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,6 +12,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.Exceptions;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using Microsoft.OpenApi.Readers.V3;
+
 using SharpYaml.Serialization;
 using Xunit;
 
@@ -675,6 +677,9 @@ get:
         [Fact]
         public void ParseTypeArrayShouldSucceed() {
             // Arrange
+            using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "documentWithTypeArray.yaml"));
+            var openApiDoc = new OpenApiStreamReader().Read(stream, out var diagnostic);
+
             var components = new OpenApiComponents
             {
                 Schemas = new Dictionary<string, OpenApiSchema>
@@ -683,19 +688,15 @@ get:
                     {
                         Type = "object",
                         Required = new HashSet<string>
-                            {
-                                "id",
-                                "name"
-                            },
+                        {
+                            "id",
+                            "name"
+                        },
                         Properties = new Dictionary<string, OpenApiSchema>
                         {
                             ["id"] = new OpenApiSchema
                             {
-                                TypeArray = new HashSet<string>
-                                {
-                                    "integer",
-                                    "null"
-                                },
+                                Type = "integer",
                                 Format = "int64"
                             },
                             ["name"] = new OpenApiSchema
@@ -704,14 +705,18 @@ get:
                             },
                             ["tag"] = new OpenApiSchema
                             {
-                                Type = "string"
+                                TypeArray = new HashSet<string>
+                                {
+                                    "string",
+                                    "null"
+                                }
                             },
                         },
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Schema,
                             Id = "pet",
-                            HostDocument = actual
+                            HostDocument = openApiDoc
                         }
                     },
                     ["errorModel"] = new OpenApiSchema
@@ -735,34 +740,90 @@ get:
                                 {
                                     "string",
                                     "null"
-                                },
+                                }
                             }
                         },
                         Reference = new OpenApiReference
                         {
                             Type = ReferenceType.Schema,
-                            Id = "errorModel"
+                            Id = "errorModel",
+                            HostDocument = openApiDoc
                         }
                     },
                 }
             };
 
             // Create a clone of the schema to avoid modifying things in components.
-            var petSchema = Clone(components.Schemas["pet"]);
+            var petSchema = new OpenApiSchema
+                    {
+                        Type = "object",
+                        Required = new HashSet<string>
+                        {
+                            "id",
+                            "name"
+                        },
+                        Properties = new Dictionary<string, OpenApiSchema>
+                        {
+                            ["id"] = new OpenApiSchema
+                            {
+                                Type = "integer",
+                                Format = "int64"
+                            },
+                            ["name"] = new OpenApiSchema
+                            {
+                                Type = "string"
+                            },
+                            ["tag"] = new OpenApiSchema
+                            {
+                                TypeArray = new HashSet<string>
+                                {
+                                    "string",
+                                    "null"
+                                }
+                            },
+                        }
+                    };
+            //Clone(components.Schemas["pet"]);
 
             petSchema.Reference = new OpenApiReference
             {
                 Id = "pet",
                 Type = ReferenceType.Schema,
-                HostDocument = actual
+                HostDocument = openApiDoc
             };
 
-            var errorModelSchema = Clone(components.Schemas["errorModel"]);
+            var errorModelSchema = new OpenApiSchema
+                    {
+                        Type = "object",
+                        Required = new HashSet<string>
+                        {
+                            "code",
+                            "message"
+                        },
+                        Properties = new Dictionary<string, OpenApiSchema>
+                        {
+                            ["code"] = new OpenApiSchema
+                            {
+                                Type = "integer",
+                                Format = "int32"
+                            },
+                            ["message"] = new OpenApiSchema
+                            {
+                                TypeArray = new HashSet<string>
+                                {
+                                    "string",
+                                    "null"
+                                }
+                            }
+                        }
+                    };
+            //Clone(components.Schemas["errorModel"]);
 
             errorModelSchema.Reference = new OpenApiReference
             {
                 Id = "errorModel",
-                Type = ReferenceType.Schema
+                Type = ReferenceType.Schema,
+                HostDocument = openApiDoc
             };
 
             var expected = new OpenApiDocument
@@ -770,130 +831,167 @@ get:
                 Info = new OpenApiInfo
                 {
                     Version = "1.0.0",
-                    Title = "Webhook Example"
+                    Title = "Swagger Petstore (Simple)",
+                    Description =
+                        "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+                    TermsOfService = new Uri("http://helloreverb.com/terms/"),
+                    Contact = new OpenApiContact
+                    {
+                        Name = "Swagger API team",
+                        Email = "foo@example.com",
+                        Url = new Uri("http://swagger.io")
+                    },
+                    License = new OpenApiLicense
+                    {
+                        Name = "MIT",
+                        Url = new Uri("http://opensource.org/licenses/MIT")
+                    }
                 },
-                Paths = new OpenApiPaths{
+                Servers = new List<OpenApiServer>
+                {
+                    new OpenApiServer
+                    {
+                        Url = "http://petstore.swagger.io/api"
+                    }
+                },
+                Paths = new OpenApiPaths
+                {
                     ["/pets/{id}"] = new OpenApiPathItem
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
-                            Operations = new Dictionary<OperationType, OpenApiOperation>
+                            [OperationType.Get] = new OpenApiOperation
                             {
-                                [OperationType.Get] = new OpenApiOperation
+                                Description =
+                                    "Returns a user based on a single ID, if the user does not have access to the pet",
+                                OperationId = "findPetById",
+                                Parameters = new List<OpenApiParameter>
                                 {
-                                    Description =
-                                        "Returns a user based on a single ID, if the user does not have access to the pet",
-                                    OperationId = "findPetById",
-                                    Parameters = new List<OpenApiParameter>
+                                    new OpenApiParameter
                                     {
-                                        new OpenApiParameter
+                                        Name = "id",
+                                        In = ParameterLocation.Path,
+                                        Description = "ID of pet to fetch",
+                                        Required = true,
+                                        Schema = new OpenApiSchema
                                         {
-                                            Name = "id",
-                                            In = ParameterLocation.Path,
-                                            Description = "ID of pet to fetch",
-                                            Required = true,
-                                            Schema = new OpenApiSchema
+                                            TypeArray = new HashSet<string>
                                             {
-                                                Type = "integer",
-                                                Format = "int64"
-                                            }
-                                        }
-                                    },
-                                    Responses = new OpenApiResponses
-                                    {
-                                        ["200"] = new OpenApiResponse
-                                        {
-                                            Description = "pet response",
-                                            Content = new Dictionary<string, OpenApiMediaType>
-                                            {
-                                                ["application/json"] = new OpenApiMediaType
-                                                {
-                                                    Schema = petSchema
-                                                },
-                                                ["application/xml"] = new OpenApiMediaType
-                                                {
-                                                    Schema = petSchema
-                                                }
-                                            }
-                                        },
-                                        ["4XX"] = new OpenApiResponse
-                                        {
-                                            Description = "unexpected client error",
-                                            Content = new Dictionary<string, OpenApiMediaType>
-                                            {
-                                                ["text/html"] = new OpenApiMediaType
-                                                {
-                                                    Schema = errorModelSchema
-                                                }
-                                            }
-                                        },
-                                        ["5XX"] = new OpenApiResponse
-                                        {
-                                            Description = "unexpected server error",
-                                            Content = new Dictionary<string, OpenApiMediaType>
-                                            {
-                                                ["text/html"] = new OpenApiMediaType
-                                                {
-                                                    Schema = errorModelSchema
-                                                }
-                                            }
+                                                "integer",
+                                                "null"
+                                            },
+                                            Format = "int64"
                                         }
                                     }
                                 },
-                                [OperationType.Delete] = new OpenApiOperation
+                                Responses = new OpenApiResponses
                                 {
-                                    Description = "deletes a single pet based on the ID supplied",
-                                    OperationId = "deletePet",
-                                    Parameters = new List<OpenApiParameter>
+                                    ["200"] = new OpenApiResponse
                                     {
-                                        new OpenApiParameter
+                                        Description = "pet response",
+                                        Content = new Dictionary<string, OpenApiMediaType>
                                         {
-                                            Name = "id",
-                                            In = ParameterLocation.Path,
-                                            Description = "ID of pet to delete",
-                                            Required = true,
-                                            Schema = new OpenApiSchema
+                                            ["application/json"] = new OpenApiMediaType
                                             {
-                                                Type = "integer",
-                                                Format = "int64"
+                                                Schema = petSchema
+                                            },
+                                            ["application/xml"] = new OpenApiMediaType
+                                            {
+                                                Schema = petSchema
                                             }
                                         }
                                     },
-                                    Responses = new OpenApiResponses
+                                    ["4XX"] = new OpenApiResponse
                                     {
-                                        ["204"] = new OpenApiResponse
+                                        Description = "unexpected client error",
+                                        Content = new Dictionary<string, OpenApiMediaType>
                                         {
-                                            Description = "pet deleted"
-                                        },
-                                        ["4XX"] = new OpenApiResponse
-                                        {
-                                            Description = "unexpected client error",
-                                            Content = new Dictionary<string, OpenApiMediaType>
+                                            ["text/html"] = new OpenApiMediaType
                                             {
-                                                ["text/html"] = new OpenApiMediaType
-                                                {
-                                                    Schema = errorModelSchema
-                                                }
+                                                Schema = errorModelSchema
                                             }
-                                        },
-                                        ["5XX"] = new OpenApiResponse
+                                        }
+                                    },
+                                    ["5XX"] = new OpenApiResponse
+                                    {
+                                        Description = "unexpected server error",
+                                        Content = new Dictionary<string, OpenApiMediaType>
                                         {
-                                            Description = "unexpected server error",
-                                            Content = new Dictionary<string, OpenApiMediaType>
+                                            ["text/html"] = new OpenApiMediaType
                                             {
-                                                ["text/html"] = new OpenApiMediaType
-                                                {
-                                                    Schema = errorModelSchema
-                                                }
+                                                Schema = errorModelSchema
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            [OperationType.Delete] = new OpenApiOperation
+                            {
+                                Description = "deletes a single pet based on the ID supplied",
+                                OperationId = "deletePet",
+                                Parameters = new List<OpenApiParameter>
+                                {
+                                    new OpenApiParameter
+                                    {
+                                        Name = "id",
+                                        In = ParameterLocation.Path,
+                                        Description = "ID of pet to delete",
+                                        Required = true,
+                                        Schema = new OpenApiSchema
+                                        {
+                                            TypeArray = new HashSet<string>
+                                            {
+                                                "integer",
+                                                "null"
+                                            },
+                                            Format = "int64"
+                                        }
+                                    }
+                                },
+                                Responses = new OpenApiResponses
+                                {
+                                    ["204"] = new OpenApiResponse
+                                    {
+                                        Description = "pet deleted"
+                                    },
+                                    ["4XX"] = new OpenApiResponse
+                                    {
+                                        Description = "unexpected client error",
+                                        Content = new Dictionary<string, OpenApiMediaType>
+                                        {
+                                            ["text/html"] = new OpenApiMediaType
+                                            {
+                                                Schema = errorModelSchema
+                                            }
+                                        }
+                                    },
+                                    ["5XX"] = new OpenApiResponse
+                                    {
+                                        Description = "unexpected server error",
+                                        Content = new Dictionary<string, OpenApiMediaType>
+                                        {
+                                            ["text/html"] = new OpenApiMediaType
+                                            {
+                                                Schema = errorModelSchema
                                             }
                                         }
                                     }
                                 }
                             }
                         }
-                    },
+                    }
+                },
                 Components = components
             };
+
             // Act
+            var generated = openApiDoc.Components;
+
             // Assert
+            generated.Should().BeEquivalentTo(expected.Components);
+
+            diagnostic.Should().BeEquivalentTo(
+                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_1 });
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiSchema/documentWithTypeArray.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiSchema/documentWithTypeArray.yaml
@@ -1,0 +1,112 @@
+openapi: '3.1.0'
+info:
+  version: '1.0.0'
+  title: Swagger Petstore (Simple)
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: Swagger API team
+    email: foo@example.com
+    url: http://swagger.io
+  license:
+    name: MIT
+    url: http://opensource.org/licenses/MIT
+servers:
+    - url: http://petstore.swagger.io/api
+paths:
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: findPetById
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type:
+              - integer
+              - null
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+                schema:
+                    "$ref": '#/components/schemas/pet'
+            application/xml:
+                schema:
+                    "$ref": '#/components/schemas/pet'
+        '4XX':
+          description: unexpected client error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+        '5XX':
+          description: unexpected server error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type:
+              - integer
+              - null
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        '4XX':
+          description: unexpected client error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+        '5XX':
+          description: unexpected server error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+components:
+    schemas:
+        pet:
+            type: object
+            required:
+            - id
+            - name
+            properties:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+              tag:
+                type:
+                  - string
+                  - null
+
+        errorModel:
+            type: object
+            required:
+            - code
+            - message
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type:
+                  - string
+                  - null
+security: []

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -463,5 +463,133 @@ namespace Microsoft.OpenApi.Tests.Models
             // Assert
             Assert.Equal(expectedV2Schema, v2Schema);
         }
+
+        [Fact]
+        public void SerializeAsV3ShouldHandleTypeArraysSchema()
+        {
+            // Arrange
+            var schema = new OpenApiSchema()
+            {
+                OneOf = new List<OpenApiSchema>
+                {
+                    new OpenApiSchema
+                    {
+                        TypeArray = new HashSet<string> { "number", "null" },
+                        Format = "decimal"
+                    },
+                }
+            };
+
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var openApiJsonWriter = new OpenApiJsonWriter(outputStringWriter, new OpenApiJsonWriterSettings { Terse = false });
+
+            // Act
+            // Serialize as V3
+            schema.SerializeAsV3(openApiJsonWriter);
+            openApiJsonWriter.Flush();
+
+            var v3Schema = outputStringWriter.GetStringBuilder().ToString().MakeLineBreaksEnvironmentNeutral();
+
+            var expectedV3Schema = @"{
+  ""oneOf"": [
+    {
+      ""type"": [
+        ""number"",
+        ""null""
+      ],
+      ""format"": ""decimal""
+    }
+  ]
+}".MakeLineBreaksEnvironmentNeutral();
+
+                // Assert
+                Assert.Equal(expectedV3Schema, v3Schema);
+        }
+
+        [Fact]
+        public void SerializeAsV3TypeArraysShouldOverrideTypeSchema()
+        {
+            // Arrange
+            var schema = new OpenApiSchema()
+            {
+                OneOf = new List<OpenApiSchema>
+                {
+                    new OpenApiSchema
+                    {
+                        TypeArray = new HashSet<string> { "number", "null" },
+                        Type = "number",
+                        Format = "decimal"
+                    },
+                }
+            };
+
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var openApiJsonWriter = new OpenApiJsonWriter(outputStringWriter, new OpenApiJsonWriterSettings { Terse = false });
+
+            // Act
+            // Serialize as V3
+            schema.SerializeAsV3(openApiJsonWriter);
+            openApiJsonWriter.Flush();
+
+            var v3Schema = outputStringWriter.GetStringBuilder().ToString().MakeLineBreaksEnvironmentNeutral();
+
+            var expectedV3Schema = @"{
+  ""oneOf"": [
+    {
+      ""type"": [
+        ""number"",
+        ""null""
+      ],
+      ""format"": ""decimal""
+    }
+  ]
+}".MakeLineBreaksEnvironmentNeutral();
+
+                // Assert
+                Assert.Equal(expectedV3Schema, v3Schema);
+        }
+
+        [Fact]
+        public void SerializeAsV3TypeArraysShouldOverrideNullableSchema()
+        {
+            // Arrange
+            var schema = new OpenApiSchema()
+            {
+                OneOf = new List<OpenApiSchema>
+                {
+                    new OpenApiSchema
+                    {
+                        TypeArray = new HashSet<string> { "number", "null" },
+                        Nullable = true,
+                        Format = "decimal"
+                    },
+                }
+            };
+
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var openApiJsonWriter = new OpenApiJsonWriter(outputStringWriter, new OpenApiJsonWriterSettings { Terse = false });
+
+            // Act
+            // Serialize as V3
+            schema.SerializeAsV3(openApiJsonWriter);
+            openApiJsonWriter.Flush();
+
+            var v3Schema = outputStringWriter.GetStringBuilder().ToString().MakeLineBreaksEnvironmentNeutral();
+
+            var expectedV3Schema = @"{
+  ""oneOf"": [
+    {
+      ""type"": [
+        ""number"",
+        ""null""
+      ],
+      ""format"": ""decimal""
+    }
+  ]
+}".MakeLineBreaksEnvironmentNeutral();
+
+                // Assert
+                Assert.Equal(expectedV3Schema, v3Schema);
+        }
     }
 }


### PR DESCRIPTION
This PR:
* Remaps nullable to type array to the OpenAPI schema object model
* Adds logic to serialize and deserialize the schema object
* Adds tests to validate serialization and deserialization

Design Decision(s):
- Opted to add a new property to the OpenApiSchema model named `TypeArray`, which will represent  the new type format
- Added logic within serialization code to handle `nullable` constraints, allowing for the reuse of the current serialization functions. However, we recommend splitting out OpenAPI 3.1 parsing into it's own execution path.

NOTES:
- As it is, the current execution path for OpenAPI 3.1 is cluttered. There are disparate approaches to allow 3.0 and 3.1 specifications to be rendered using the same function. I am considering splitting out this functionality - let me know your thoughts.
